### PR TITLE
Improve background task visibility and session behavior

### DIFF
--- a/shared/session-control-commands.ts
+++ b/shared/session-control-commands.ts
@@ -1,6 +1,7 @@
 export const SESSION_COMPACT_COMMAND = '/compact' as const;
 export const SESSION_CLEAR_COMMAND = '/clear' as const;
 export const SESSION_STOP_COMMAND = '/stop' as const;
+export const SESSION_MODEL_COMMAND = '/model' as const;
 export const SESSION_CONTROL_METADATA_COMMAND_FIELD = 'controlCommand' as const;
 export const SESSION_CONTROL_TIMELINE_STATE_COMPACTING = 'compacting' as const;
 export const SESSION_CONTROL_TIMELINE_REASON_USER_COMPACT = 'user_compact' as const;
@@ -92,6 +93,14 @@ export function isSessionCompactCommandText(text: string): boolean {
 
 export function isSessionClearCommandText(text: string): boolean {
   return isSessionControlCommandText(text, 'clear');
+}
+
+/** Match a complete model-switch command while leaving ordinary prose untouched. */
+export function isSessionModelSwitchCommandText(text: string): boolean {
+  const normalized = text.trim();
+  if (!normalized.startsWith(SESSION_MODEL_COMMAND)) return false;
+  const argumentsText = normalized.slice(SESSION_MODEL_COMMAND.length);
+  return /^\s+\S+(?:\s+.*)?$/.test(argumentsText);
 }
 
 export function isDaemonHandledSessionControlSend(text: string): boolean {

--- a/src/agent/providers/claude-code-sdk.ts
+++ b/src/agent/providers/claude-code-sdk.ts
@@ -1658,11 +1658,18 @@ export class ClaudeCodeSdkProvider implements TransportProvider, InteractiveQues
       if (typeof patch?.is_backgrounded === 'boolean') task.backgrounded = patch.is_backgrounded;
       this.applyClaudeTaskStatus(task, this.pickString(patch?.status));
     } else if (msg.subtype === 'task_notification') {
-      task.summary = this.pickShortString(msg.summary) ?? task.summary;
-      task.model = this.readRuntimeSubagentModel(msg) ?? task.model;
-      task.outputFile = this.pickShortString(msg.output_file) ?? task.outputFile;
-      task.usage = this.normalizeClaudeTaskUsage(msg.usage) ?? task.usage;
-      this.applyClaudeTaskStatus(task, this.pickString(msg.status));
+      const statusAccepted = this.applyClaudeTaskStatus(task, this.pickString(msg.status));
+      // Claude can replay a degraded notification after a session boundary
+      // (for example, "stopped" with no completion record) even though the
+      // same task already delivered an authoritative completed result. Keep
+      // the accepted terminal state and its matching output together instead
+      // of allowing rejected status metadata to overwrite the visible result.
+      if (statusAccepted) {
+        task.summary = this.pickShortString(msg.summary) ?? task.summary;
+        task.model = this.readRuntimeSubagentModel(msg) ?? task.model;
+        task.outputFile = this.pickShortString(msg.output_file) ?? task.outputFile;
+        task.usage = this.normalizeClaudeTaskUsage(msg.usage) ?? task.usage;
+      }
     }
 
     // Claude registers local_bash only after the shell command has detached
@@ -2209,11 +2216,11 @@ export class ClaudeCodeSdkProvider implements TransportProvider, InteractiveQues
     if (status !== 'running') state.runtimeAgentToolCalls.delete(tool.id);
   }
 
-  private applyClaudeTaskStatus(task: ClaudeTaskState, rawStatus: string | undefined): void {
-    if (!rawStatus) return;
+  private applyClaudeTaskStatus(task: ClaudeTaskState, rawStatus: string | undefined): boolean {
+    if (!rawStatus) return true;
     const { normalizedStatus, terminal, diagnosticCode } = this.normalizeClaudeTaskStatus(rawStatus);
     if (task.terminal && (normalizedStatus === SDK_SUBAGENT_STATUS.RUNNING || normalizedStatus === SDK_SUBAGENT_STATUS.PENDING)) {
-      return;
+      return false;
     }
     if (
       task.terminal
@@ -2221,7 +2228,7 @@ export class ClaudeCodeSdkProvider implements TransportProvider, InteractiveQues
       && terminal
       && normalizedStatus === SDK_SUBAGENT_STATUS.UNKNOWN
     ) {
-      return;
+      return false;
     }
     if (
       task.terminal
@@ -2229,7 +2236,7 @@ export class ClaudeCodeSdkProvider implements TransportProvider, InteractiveQues
       && terminal
       && normalizedStatus !== task.normalizedStatus
     ) {
-      return;
+      return false;
     }
 
     task.rawStatus = rawStatus;
@@ -2238,6 +2245,7 @@ export class ClaudeCodeSdkProvider implements TransportProvider, InteractiveQues
     task.normalizedStatus = normalizedStatus;
     task.terminal = terminal;
     task.active = this.isClaudeSubagentActive(normalizedStatus) && !terminal;
+    return true;
   }
 
   private normalizeClaudeTaskStatus(rawStatus: string): {

--- a/src/agent/providers/claude-code-sdk.ts
+++ b/src/agent/providers/claude-code-sdk.ts
@@ -1665,6 +1665,15 @@ export class ClaudeCodeSdkProvider implements TransportProvider, InteractiveQues
       this.applyClaudeTaskStatus(task, this.pickString(msg.status));
     }
 
+    // Claude registers local_bash only after the shell command has detached
+    // from the foreground turn. task_updated(is_backgrounded) can arrive later
+    // (or not at all before the parent completes), so derive the non-blocking
+    // ownership immediately from the provider-native task type. Without this,
+    // TransportSessionRuntime treats the row as a foreground open tool and
+    // synthesizes a false success when the parent turn settles, even though the
+    // background process is still running.
+    if (task.taskType === CLAUDE_LOCAL_BASH_TASK_TYPE) task.backgrounded = true;
+
     if (task.terminal && !task.parentWakeHandled) {
       task.parentWakeHandled = true;
       if (state.currentQuery && state.completed && state.retainedSubagentMode) {

--- a/src/context/live-context-ingestion.ts
+++ b/src/context/live-context-ingestion.ts
@@ -13,6 +13,7 @@ import { scheduleMarkdownMemoryIngest } from './md-ingest-worker.js';
 import { subscribeRuntimeMemoryCacheInvalidation } from './runtime-memory-cache-bus.js';
 import { serializeContextTarget } from './context-keys.js';
 import { incrementCounter } from '../util/metrics.js';
+import { isSessionModelSwitchCommandText } from '../../shared/session-control-commands.js';
 
 const BOOTSTRAP_CACHE_MS = 30_000;
 const INGEST_RETRY_BUFFER_MAX_EVENTS = 256;
@@ -649,13 +650,16 @@ function toSessionTarget(sessionName: string, bootstrap: TransportContextBootstr
 
 function mapTimelineEvent(event: TimelineEvent): Pick<LocalContextEvent, 'eventType' | 'content' | 'metadata'> | null {
   switch (event.type) {
-    case 'user.message':
+    case 'user.message': {
       if (event.payload.memoryExcluded === true) return null;
+      const text = stringifyContent(event.payload.text);
+      if (text && isSessionModelSwitchCommandText(text)) return null;
       return {
         eventType: 'user.turn',
-        content: stringifyContent(event.payload.text),
+        content: text,
         metadata: { timelineType: event.type },
       };
+    }
     case 'assistant.text': {
       const text = stringifyContent(event.payload.text);
       if (event.payload.streaming === true || event.payload.memoryExcluded === true) return null;

--- a/src/daemon/timeline-emitter.ts
+++ b/src/daemon/timeline-emitter.ts
@@ -17,6 +17,7 @@ import { getSession } from '../store/session-store.js';
 import logger from '../util/logger.js';
 import { recordTimelineEmit } from './latency-tracer.js';
 import { TIMELINE_RESPONSE_SOURCES, type TimelineResponseSource } from '../../shared/timeline-protocol.js';
+import { isSessionModelSwitchCommandText } from '../../shared/session-control-commands.js';
 
 /** Pattern matching temp file instruction: "Read and execute all instructions in @<path>" */
 const TEMP_FILE_RE = /^Read and execute all instructions in @(.+\.imcodes-prompt-[0-9a-f]+\.md)$/;
@@ -139,6 +140,13 @@ export class TimelineEmitter {
     if (type === 'user.message') {
       const text = String(payload.text ?? '');
       const allowDuplicate = payload.allowDuplicate === true;
+
+      // Model selection is operational session metadata, not durable project
+      // knowledge. Keep the command visible in the timeline while preventing
+      // both live ingestion and later history backfill from learning it.
+      if (isSessionModelSwitchCommandText(text)) {
+        payload = { ...payload, memoryExcluded: true };
+      }
 
       // Resolve temp file references: replace instruction with actual file content.
       // Guard with a `statSync` size check so an oversized paste does not block

--- a/test/agent/claude-code-sdk-provider.test.ts
+++ b/test/agent/claude-code-sdk-provider.test.ts
@@ -2276,6 +2276,59 @@ describe('ClaudeCodeSdkProvider', () => {
     expect(JSON.stringify(terminal?.input ?? null)).not.toContain('/tmp/full-output.log');
   });
 
+  it('preserves authoritative completion output when a late notification reports a conflicting terminal status', async () => {
+    const sessionName = 'deck_project_claude_late_degraded_notification';
+    const { tools } = await collectToolsForMessages([
+      { type: 'system', subtype: 'init', session_id: 'session-route-subagent-late-degraded', model: 'claude-sonnet-4-6' },
+      {
+        type: 'system',
+        subtype: 'task_started',
+        session_id: 'session-route-subagent-late-degraded',
+        uuid: 'uuid-task-late-degraded-start',
+        task_id: 'task-late-degraded-1',
+        description: 'Run a background Bash verification',
+        task_type: 'local_bash',
+      },
+      {
+        type: 'system',
+        subtype: 'task_notification',
+        session_id: 'session-route-subagent-late-degraded',
+        uuid: 'uuid-task-late-degraded-complete',
+        task_id: 'task-late-degraded-1',
+        status: 'completed',
+        summary: 'Background command completed (exit code 0)',
+      },
+      {
+        type: 'system',
+        subtype: 'task_notification',
+        session_id: 'session-route-subagent-late-degraded',
+        uuid: 'uuid-task-late-degraded-stopped',
+        task_id: 'task-late-degraded-1',
+        status: 'stopped',
+        summary: 'No completion record was found for this background shell command from the previous session.',
+      },
+      { type: 'result', session_id: 'session-route-subagent-late-degraded', subtype: 'success', is_error: false, result: 'OK', usage: { input_tokens: 1, output_tokens: 1, cache_read_input_tokens: 0 } },
+    ], 'route-subagent-late-degraded', sessionName);
+
+    const subagents = sdkSubagentTools(tools);
+    expect(subagents).toHaveLength(2);
+    expect(subagents.at(-1)).toMatchObject({
+      id: makeClaudeSubagentCanonicalKey(sessionName, 'task-late-degraded-1'),
+      name: 'Bash',
+      status: 'complete',
+      output: 'Background command completed (exit code 0)',
+      detail: {
+        summary: 'Background command completed (exit code 0)',
+        meta: {
+          rawStatus: 'completed',
+          normalizedStatus: SDK_SUBAGENT_STATUS.COMPLETE,
+          active: false,
+          terminal: true,
+        },
+      },
+    });
+  });
+
   it.each(['failed', 'stopped', 'killed'] as const)('emits terminal error SDK subagent snapshots for Claude task_notification %s', async (status) => {
     const sessionName = `deck_project_claude_${status}`;
     const { tools } = await collectToolsForMessages([

--- a/test/agent/claude-code-sdk-provider.test.ts
+++ b/test/agent/claude-code-sdk-provider.test.ts
@@ -1613,6 +1613,7 @@ describe('ClaudeCodeSdkProvider', () => {
         meta: {
           taskId: 'bp1xwk3v9',
           taskType: 'local_bash',
+          backgrounded: true,
           normalizedStatus: SDK_SUBAGENT_STATUS.COMPLETE,
           active: false,
           terminal: true,

--- a/test/daemon/live-context-ingestion.test.ts
+++ b/test/daemon/live-context-ingestion.test.ts
@@ -991,6 +991,7 @@ describe('LiveContextIngestion', () => {
     });
 
     await ingestion.backfillSessionFromEvents(session.name, [
+      makeEvent('user.message', 99, { text: '/model gpt-5.4' }),
       makeEvent('user.message', 100, { text: 'Summarize the deployment plan' }),
       makeEvent('assistant.text', 101, { text: 'Deployment plan captured' }),
     ]);
@@ -1001,6 +1002,8 @@ describe('LiveContextIngestion', () => {
         summary: expect.stringContaining('**Assistant:** Deployment plan captured'),
       }),
     ]);
+    expect(queryProcessedProjections({ scope: 'personal', projectId: namespace.projectId, limit: 10 })[0]?.summary)
+      .not.toContain('/model gpt-5.4');
     expect(getProcessedProjectionStats({ scope: 'personal', projectId: namespace.projectId })).toMatchObject({
       totalRecords: 1,
       stagedEventCount: 0,

--- a/test/daemon/timeline-emitter.test.ts
+++ b/test/daemon/timeline-emitter.test.ts
@@ -95,6 +95,20 @@ describe('TimelineEmitter — seq counter', () => {
     expect(events[0]?.payload.text).toBe('retry');
   });
 
+  it('marks model-switch user messages as excluded from memory while keeping them visible', () => {
+    const event = emitter.emit('session-a', 'user.message', {
+      text: '/model anthropic/claude-sonnet-4-5',
+      commandId: 'cmd-model',
+    });
+
+    expect(event?.payload).toMatchObject({
+      text: '/model anthropic/claude-sonnet-4-5',
+      commandId: 'cmd-model',
+      memoryExcluded: true,
+    });
+    expect(emitter.replay('session-a', 0).events).toHaveLength(1);
+  });
+
 
   it('marks pure API failure assistant text as non-memory answer text at emit time', () => {
     const event = emitter.emit('session-a', 'assistant.text', {

--- a/test/daemon/transport-session-runtime.test.ts
+++ b/test/daemon/transport-session-runtime.test.ts
@@ -23,6 +23,7 @@ import {
   SDK_SUBAGENT_PROVIDERS,
   SDK_SUBAGENT_PROVIDER_KINDS,
   SDK_SUBAGENT_STATUS,
+  SDK_SUBAGENT_TASK_TYPES,
 } from '../../shared/sdk-subagent-status.js';
 import { setContextModelRuntimeConfig } from '../../src/context/context-model-config.js';
 import type { SharedActorEnvelope } from '../../shared/tab-sharing.js';
@@ -728,6 +729,53 @@ describe('TransportSessionRuntime', () => {
         terminalReason: 'provider_result',
       }),
       expect.objectContaining({ source: 'daemon', confidence: 'high' }),
+    );
+  });
+
+  it('does not synthesize a terminal for Claude local_bash when its foreground turn completes', async () => {
+    runtime.send('start a detached render', 'cmd-local-bash-parent');
+    await waitForProviderSendCount(mock.provider, 1);
+
+    const canonicalKey = 'claude:deck_test_brain:background-render';
+    mock.fireTool('sess-1', {
+      id: canonicalKey,
+      name: 'Bash',
+      status: 'running',
+      input: {
+        action: 'claude-bash-task',
+        description: 'Render all video frames',
+      },
+      detail: {
+        kind: SDK_SUBAGENT_DETAIL_KIND,
+        summary: 'Claude Bash task',
+        meta: {
+          isSdkSubagent: true,
+          schemaVersion: 1,
+          provider: SDK_SUBAGENT_PROVIDERS.CLAUDE_CODE_SDK,
+          providerKind: SDK_SUBAGENT_PROVIDER_KINDS.CLAUDE_TASK,
+          canonicalKey,
+          normalizedStatus: SDK_SUBAGENT_STATUS.RUNNING,
+          rawStatus: 'running',
+          active: true,
+          terminal: false,
+          backgrounded: true,
+          taskType: SDK_SUBAGENT_TASK_TYPES.LOCAL_BASH,
+          taskId: 'background-render',
+        },
+      },
+    });
+    await flushDispatch();
+
+    expect((runtime as unknown as { _openTools: Map<string, unknown> })._openTools.size).toBe(0);
+    mock.fireComplete('sess-1');
+    await flushDispatch();
+
+    expect(runtime.getStatus()).toBe('idle');
+    expect(timelineEmitterEmitMock).not.toHaveBeenCalledWith(
+      'deck_test_brain',
+      'tool.result',
+      expect.objectContaining({ toolCallId: canonicalKey }),
+      expect.anything(),
     );
   });
 

--- a/test/shared/session-control-commands.test.ts
+++ b/test/shared/session-control-commands.test.ts
@@ -4,6 +4,7 @@ import {
   getSessionControlTimelineFeedback,
   getSessionControlTimelineFeedbackById,
   isDaemonHandledSessionControlSend,
+  isSessionModelSwitchCommandText,
   isSessionControlCommandText,
   SESSION_CONTROL_TIMELINE_REASON_USER_COMPACT,
   SESSION_CONTROL_TIMELINE_STATE_COMPACTING,
@@ -89,5 +90,14 @@ describe('session control command abstraction', () => {
     expect(isSessionControlCommandText('/compact now', 'compact')).toBe(false);
     expect(classifySessionControlCommand('/clear please')).toBeNull();
     expect(shouldResetProcessPreferenceContextForSessionControl('/model gpt-5.4')).toBe(false);
+  });
+
+  it('recognizes complete model-switch commands without matching ordinary prose', () => {
+    expect(isSessionModelSwitchCommandText('/model gpt-5.4')).toBe(true);
+    expect(isSessionModelSwitchCommandText('  /model anthropic/claude-sonnet-4-5  ')).toBe(true);
+    expect(isSessionModelSwitchCommandText('/model\tgpt-5.4')).toBe(true);
+    expect(isSessionModelSwitchCommandText('/model')).toBe(false);
+    expect(isSessionModelSwitchCommandText('/modelfoo')).toBe(false);
+    expect(isSessionModelSwitchCommandText('Please run /model gpt-5.4')).toBe(false);
   });
 });

--- a/test/store/session-store.test.ts
+++ b/test/store/session-store.test.ts
@@ -76,7 +76,10 @@ beforeEach(() => {
 });
 
 afterEach(() => {
-  rmSync(tempDir, { recursive: true, force: true });
+  // A fresh-process persistence test can finish while the filesystem is still
+  // settling its final sessions.json write. Let Node retry the recursive
+  // removal if that brief race recreates an entry during directory traversal.
+  rmSync(tempDir, { recursive: true, force: true, maxRetries: 5, retryDelay: 20 });
   vi.unstubAllEnvs();
   // The partial-mock regression test must not contaminate later tests in this
   // file or a reused full-suite worker.

--- a/web/src/components/ChatView.tsx
+++ b/web/src/components/ChatView.tsx
@@ -1757,11 +1757,14 @@ export function ChatView({ events, loading, refreshing = false, historyStatus, l
   );
   const hasAgentsStatusRows = sdkAgentsStatus.rows.length > 0 || sdkAgentsStatus.diagnostics.length > 0;
   useEffect(() => {
-    if (preview || !hasAgentsStatusRows) return undefined;
+    if (!hasAgentsStatusRows) return undefined;
     const timer = window.setInterval(() => setSdkAgentsNow(Date.now()), 1_000);
     return () => window.clearInterval(timer);
-  }, [hasAgentsStatusRows, preview]);
-  const canShowAgentsControl = !preview;
+  }, [hasAgentsStatusRows]);
+  // Preview cards reuse the existing Agents panel when background work exists.
+  // The aggregator only accepts sdkSubagent events, so ordinary Bash tool calls
+  // never make this control or panel appear.
+  const canShowAgentsControl = !preview || hasAgentsStatusRows;
   // Keep the panel mounted for every retained sub-agent row, not only while at
   // least one child is currently running. Otherwise a just-finished child (or
   // a provider diagnostic) makes the entire list disappear even though the

--- a/web/src/components/FileBrowser.tsx
+++ b/web/src/components/FileBrowser.tsx
@@ -1861,7 +1861,6 @@ export function FileBrowser({
               controls
               preload="metadata"
               playsInline
-              style={{ maxWidth: '100%', maxHeight: '100%', width: '100%', background: '#000' }}
             >
               <source src={preview.streamUrl} type={preview.mimeType} />
               {t('file_browser.preview_video_unsupported')}

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -3354,6 +3354,12 @@ html.native-ios-mac .chat-dl-btn {
 .subcard-ctx-cache { position: absolute; left: 0; top: 0; height: 100%; background: linear-gradient(90deg, var(--chrome-accent-3), #818cf8); border-radius: 999px; box-shadow: 0 0 10px rgba(129,140,248,0.36); }
 
 .subcard-preview { flex: 1; overflow-y: auto; overflow-x: hidden; }
+/* A preview card is much narrower than a full chat window. Reuse the existing
+   Agents panel, but stack it below the chat so its 240-360px desktop sidebar
+   width cannot collapse the card's chat preview. The panel body remains
+   scrollable and is capped to preserve most of the card for conversation. */
+.subcard-preview .chat-view-wrap.chat-split { height: 100%; flex-direction: column !important; }
+.subcard-preview .chat-sdk-agents-panel { width: 100% !important; min-width: 0; min-height: 0; max-height: min(42%, 120px); flex-shrink: 0; border-left: 0; border-top: 1px solid #334155; }
 .subcard-preview-terminal { display: flex; min-height: 0; }
 .subcard-preview-terminal .terminal-wrap { width: 100%; height: 100%; min-height: 0; }
 .subcard-scroll-bottom { position: absolute; bottom: 6px; right: 10px; width: 26px; height: 26px; border-radius: 50%; background: #334155; border: 1px solid #475569; color: #e2e8f0; font-size: 14px; cursor: pointer; display: flex; align-items: center; justify-content: center; z-index: 5; opacity: 0.8; transition: opacity 0.15s; line-height: 1; padding: 0; }

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -4725,8 +4725,8 @@ html.native-ios-mac .chat-dl-btn {
 .fb-icon-spin { display: inline-block; animation: spin 0.8s linear infinite; }
 .fb-preview-image { display: flex; align-items: center; justify-content: center; padding: 16px; overflow: auto; background: #0a0f1a; min-height: 0; flex: 1; }
 .fb-preview-image img { max-width: 100%; max-height: 100%; object-fit: contain; border-radius: 4px; background: repeating-conic-gradient(#1e293b 0% 25%, #0f172a 0% 50%) 0 0 / 16px 16px; cursor: zoom-in; }
-.fb-preview-video { display: flex; align-items: center; justify-content: center; padding: 16px; overflow: hidden; background: #0a0f1a; min-height: 0; flex: 1; }
-.fb-preview-video video { max-width: 100%; max-height: 100%; width: 100%; border-radius: 4px; background: #000; outline: none; }
+.fb-preview-video { display: flex; align-items: center; justify-content: center; height: 100%; padding: 16px; box-sizing: border-box; overflow: hidden; background: #0a0f1a; min-height: 0; flex: 1; }
+.fb-preview-video video { width: auto; height: 100%; max-width: 100%; max-height: 100%; object-fit: contain; border-radius: 4px; background: #000; outline: none; }
 .fb-preview-audio { display: flex; align-items: center; justify-content: center; padding: 24px; overflow: auto; background: #0a0f1a; min-height: 0; flex: 1; }
 .fb-preview-audio-card { width: min(560px, 100%); display: flex; flex-direction: column; gap: 16px; align-items: center; padding: 24px; border: 1px solid rgba(148, 163, 184, 0.22); border-radius: 12px; background: rgba(15, 23, 42, 0.82); color: #e2e8f0; box-shadow: 0 12px 36px rgba(0, 0, 0, 0.24); }
 .fb-preview-audio-icon { width: 56px; height: 56px; border-radius: 50%; display: flex; align-items: center; justify-content: center; font-size: 32px; font-weight: 700; background: linear-gradient(135deg, #38bdf8, #6366f1); color: #fff; }

--- a/web/test/components/ChatView-sdk-agents.test.tsx
+++ b/web/test/components/ChatView-sdk-agents.test.tsx
@@ -178,6 +178,57 @@ describe('ChatView SDK agents panel', () => {
       .toEqual(['Bash / Shell', 'Agent', 'Bash / Shell']);
   });
 
+  it('reuses the Agents panel in preview for background Bash and Agent work only', () => {
+    localStorage.setItem('chatSdkAgentsPanelOpen:desktop', '1');
+    const backgroundBash = makeSdkEvent('bash-running', makeMeta({
+      canonicalKey: 'claude:deck_agents:bash-preview',
+      taskId: 'bash-preview',
+      taskType: SDK_SUBAGENT_TASK_TYPES.LOCAL_BASH,
+      childStatusSummary: 'Running focused tests',
+    }));
+    const backgroundAgent = makeSdkEvent('agent-running', makeMeta({
+      canonicalKey: 'claude:deck_agents:agent-preview',
+      taskId: 'agent-preview',
+      taskType: SDK_SUBAGENT_TASK_TYPES.LOCAL_AGENT,
+      childStatusSummary: 'Reviewing the result',
+    }));
+    const ordinaryBash: TimelineEvent = {
+      eventId: 'ordinary-bash',
+      sessionId: 'deck_agents',
+      ts: Date.now(),
+      seq: 2,
+      epoch: 1,
+      source: 'daemon',
+      confidence: 'high',
+      type: 'tool.call',
+      payload: {
+        tool: 'Bash',
+        input: { command: 'pwd' },
+        detail: { kind: 'tool_use', summary: 'ordinary short bash' },
+      },
+    };
+
+    const { container } = render(
+      <ChatView
+        events={[ordinaryBash, backgroundBash, backgroundAgent]}
+        loading={false}
+        sessionId="deck_agents"
+        preview
+      />,
+    );
+
+    const panel = container.querySelector('.chat-sdk-agents-panel');
+    expect(panel).toBeTruthy();
+    expect(panel?.textContent).toContain('2 running');
+    expect(panel?.textContent).toContain('Bash / Shell');
+    expect(panel?.textContent).toContain('Agent');
+    expect(panel?.textContent).toContain('Running focused tests');
+    expect(panel?.textContent).toContain('Reviewing the result');
+    expect(panel?.textContent).not.toContain('ordinary short bash');
+    expect(container.querySelectorAll('.chat-sdk-agent-row')).toHaveLength(2);
+    expect(container.querySelector('.chat-sdk-agents-toggle')).toBeTruthy();
+  });
+
   it('renders the Agents toggle immediately before refresh and shows the running badge', () => {
     const onForceSync = vi.fn();
     const { container } = render(

--- a/web/test/styles-contract.test.ts
+++ b/web/test/styles-contract.test.ts
@@ -41,6 +41,27 @@ describe('styles.css regression contracts', () => {
     expect(subcardRule![0]).toMatch(/overflow-y:\s*auto/);
   });
 
+  it('fits portrait videos by available preview height without stretching them to full width', () => {
+    const videoContainerRule = css.match(/\.fb-preview-video\s*\{[^}]*\}/);
+    expect(videoContainerRule).not.toBeNull();
+    expect(videoContainerRule![0]).toMatch(/height:\s*100%/);
+    expect(videoContainerRule![0]).toMatch(/box-sizing:\s*border-box/);
+
+    const videoRule = css.match(/\.fb-preview-video video\s*\{[^}]*\}/);
+    expect(videoRule).not.toBeNull();
+    expect(videoRule![0]).toMatch(/width:\s*auto/);
+    expect(videoRule![0]).toMatch(/height:\s*100%/);
+    expect(videoRule![0]).toMatch(/max-width:\s*100%/);
+    expect(videoRule![0]).toMatch(/max-height:\s*100%/);
+    expect(videoRule![0]).toMatch(/object-fit:\s*contain/);
+    expect(videoRule![0]).not.toMatch(/[;{]\s*width:\s*100%/);
+
+    const fileBrowser = readFileSync(resolve(__dirname, '../src/components/FileBrowser.tsx'), 'utf8');
+    const videoElement = fileBrowser.match(/<video[\s\S]*?>/);
+    expect(videoElement).not.toBeNull();
+    expect(videoElement![0]).not.toContain('style=');
+  });
+
   it('stacks the existing Agents panel in narrow sub-session previews', () => {
     const previewSplitRule = css.match(/\.subcard-preview \.chat-view-wrap\.chat-split\s*\{[^}]*\}/);
     expect(previewSplitRule).not.toBeNull();

--- a/web/test/styles-contract.test.ts
+++ b/web/test/styles-contract.test.ts
@@ -41,6 +41,19 @@ describe('styles.css regression contracts', () => {
     expect(subcardRule![0]).toMatch(/overflow-y:\s*auto/);
   });
 
+  it('stacks the existing Agents panel in narrow sub-session previews', () => {
+    const previewSplitRule = css.match(/\.subcard-preview \.chat-view-wrap\.chat-split\s*\{[^}]*\}/);
+    expect(previewSplitRule).not.toBeNull();
+    expect(previewSplitRule![0]).toMatch(/flex-direction:\s*column\s*!important/);
+
+    const previewAgentsRule = css.match(/\.subcard-preview \.chat-sdk-agents-panel\s*\{[^}]*\}/);
+    expect(previewAgentsRule).not.toBeNull();
+    expect(previewAgentsRule![0]).toMatch(/width:\s*100%\s*!important/);
+    expect(previewAgentsRule![0]).toMatch(/min-width:\s*0/);
+    expect(previewAgentsRule![0]).toMatch(/max-height:\s*min\(42%,\s*120px\)/);
+    expect(previewAgentsRule![0]).toMatch(/border-top:\s*1px solid #334155/);
+  });
+
   it('sub-session accents stay on card/button top borders and window full borders', () => {
     const cardRule = css.match(/\.subcard\s*\{[^}]*\}/);
     expect(cardRule).not.toBeNull();


### PR DESCRIPTION
## Summary
- exclude `/model` switch commands from memory while retaining timeline history
- surface Claude background Bash work in the existing Agents panel, including compact preview layout
- keep background Bash lifecycle active until the real provider terminal event arrives
- preserve authoritative task completion output against late conflicting notifications
- fit portrait video previews by available height
- stabilize session-store cleanup under CI contention

## Validation
- real 60s and 120s Claude background Bash runs completed with exit code 0 and were visible in the frontend
- A1 focused validation on host 211: 209/209 tests passed
- root TypeScript check passed on host 211
- daemon production build passed on host 211
- prior commit CI run 29977334512 passed 24/24 jobs

Local compilation/testing was intentionally not run on host 111 per the device update policy.