### PR TITLE
Preserve saved auditor across quick mode switches

### DIFF
--- a/web/src/components/SessionControls.tsx
+++ b/web/src/components/SessionControls.tsx
@@ -2112,7 +2112,12 @@ export function SessionControls({ ws, activeSession, connected: connectedProp, i
     };
 
     if (nextMode === SUPERVISION_MODE.OFF) {
-      const nextTransportConfig = buildTransportConfigWithSupervision(currentTransportConfig, { mode: SUPERVISION_MODE.OFF });
+      const nextTransportConfig = buildTransportConfigWithSupervision(
+        currentTransportConfig,
+        supervisionSnapshot
+          ? { ...supervisionSnapshot, mode: SUPERVISION_MODE.OFF }
+          : { mode: SUPERVISION_MODE.OFF },
+      );
       try {
         await persistTransportConfig(nextTransportConfig);
         setAutoOpen(false);

--- a/web/test/components/SessionControls.test.tsx
+++ b/web/test/components/SessionControls.test.tsx
@@ -5328,6 +5328,65 @@ afterEach(() => {
     expect(onSettings).not.toHaveBeenCalled();
   });
 
+  it('keeps the current session auditor when quick mode is turned off and reuses it on audit', async () => {
+    const onSettings = vi.fn();
+    render(
+      <SessionControls
+        ws={makeWs() as any}
+        serverId="srv1"
+        activeSession={makeTransportSession({
+          name: 'deck_proj_brain',
+          role: 'brain',
+          state: 'idle',
+          transportConfig: {
+            supervision: {
+              mode: 'supervised_audit',
+              backend: 'codex-sdk',
+              model: 'gpt-5.6-sol',
+              timeoutMs: 12000,
+              promptVersion: 'supervision_decision_v1',
+              auditTargetSessionName: 'deck_sub_peer',
+              peerAuditPromptVersion: 'supervision_peer_audit_v1',
+            },
+          },
+        })}
+        onSettings={onSettings}
+        quickData={makeQuickData() as any}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: /^Auto$/ }));
+    fireEvent.click(screen.getByRole('button', { name: /off$/i }));
+    await waitFor(() => expect(patchSessionMock).toHaveBeenLastCalledWith(
+      'srv1',
+      'deck_proj_brain',
+      expect.objectContaining({
+        transportConfig: expect.objectContaining({
+          supervision: expect.objectContaining({
+            mode: 'off',
+            auditTargetSessionName: 'deck_sub_peer',
+          }),
+        }),
+      }),
+    ));
+
+    fireEvent.click(screen.getByRole('button', { name: /^Auto$/ }));
+    fireEvent.click(screen.getByRole('button', { name: /supervised_audit$/i }));
+    await waitFor(() => expect(patchSessionMock).toHaveBeenLastCalledWith(
+      'srv1',
+      'deck_proj_brain',
+      expect.objectContaining({
+        transportConfig: expect.objectContaining({
+          supervision: expect.objectContaining({
+            mode: 'supervised_audit',
+            auditTargetSessionName: 'deck_sub_peer',
+          }),
+        }),
+      }),
+    ));
+    expect(onSettings).not.toHaveBeenCalled();
+  });
+
   it('keeps legacy fingerprint metadata optional when compact audit is enabled', async () => {
     const onSettings = vi.fn();
     render(


### PR DESCRIPTION
## Summary
- preserve the current session's remembered peer auditor when Quick Auto is turned off
- reuse that saved auditor when switching the same session back to audit
- add a real off-to-audit interaction regression test

## Validation
- machine 211: SessionControls focused suite — 211 passed, 8 skipped
- machine 211: Web TypeScript check passed
- machine 211: Web production build passed

No tests or builds were run on machine 111.