### PR TITLE
fix: align production remote desktop handshake with dev

### DIFF
--- a/native/windows-remote-desktop/display_capture.cc
+++ b/native/windows-remote-desktop/display_capture.cc
@@ -87,6 +87,16 @@ bool IsImcodesVirtualDisplay(const wchar_t* device_name) {
   }
 }
 
+bool HasActiveMonitorTarget(const wchar_t* device_name) {
+  if (!device_name || !*device_name) return false;
+  for (DWORD index = 0;; ++index) {
+    DISPLAY_DEVICEW monitor{};
+    monitor.cb = sizeof(monitor);
+    if (!EnumDisplayDevicesW(device_name, index, &monitor, 0)) return false;
+    if ((monitor.StateFlags & DISPLAY_DEVICE_ACTIVE) != 0) return true;
+  }
+}
+
 constexpr DISPLAYCONFIG_DEVICE_INFO_TYPE kGetSourceDpiScale =
     static_cast<DISPLAYCONFIG_DEVICE_INFO_TYPE>(-3);
 constexpr DISPLAYCONFIG_DEVICE_INFO_TYPE kSetSourceDpiScale =
@@ -209,6 +219,14 @@ std::vector<DisplayInfo> EnumerateDisplays() {
       info.primary = desc.DesktopCoordinates.left == 0 &&
                      desc.DesktopCoordinates.top == 0;
       info.imcodes_virtual = IsImcodesVirtualDisplay(desc.DeviceName);
+      if (!DisplayOutputIsPresentable(
+              info.imcodes_virtual,
+              HasActiveMonitorTarget(desc.DeviceName))) {
+        RTC_LOG(LS_WARNING)
+            << "Ignoring attached DXGI output without an active monitor target: "
+            << info.label;
+        continue;
+      }
       if (info.imcodes_virtual) info.label = "IM.codes Headless Display";
       info.adapter_luid = adapter_desc.AdapterLuid;
       info.output_index = output_index;

--- a/native/windows-remote-desktop/json_protocol.h
+++ b/native/windows-remote-desktop/json_protocol.h
@@ -17,7 +17,10 @@ inline constexpr size_t kMaxDataMessageBytes = 16 * 1024;
 inline constexpr size_t kMaxClipboardTextBytes = 12 * 1024;
 inline constexpr int kMaxIceCandidates = 128;
 inline constexpr int kMaxDisplays = 16;
-inline constexpr int64_t kLeaseMaxFutureMs = 20'000;
+// The Server grants a 60 s controller lease and renews it every 15 s.  Accept
+// bounded clock/skew and IPC scheduling headroom beyond the normal lease, but
+// never let a malformed authority turn into an unbounded worker lifetime.
+inline constexpr int64_t kLeaseMaxFutureMs = 75'000;
 inline constexpr int64_t kIdleTimeoutMs = 15 * 60 * 1000;
 // How long the picture waits for the input channels before going out anyway.
 // Their handshake is a handful of small packets, so this is a backstop for a

--- a/native/windows-remote-desktop/json_protocol_unittest.cc
+++ b/native/windows-remote-desktop/json_protocol_unittest.cc
@@ -71,6 +71,18 @@ TEST(JsonProtocolTest, RejectsExpiredAndOverlongLeaseAuthorities) {
   EXPECT_FALSE(ParseServiceSignal(root, kNowMs).has_value());
 }
 
+TEST(JsonProtocolTest, AcceptsTheBoundedSixtySecondControllerLease) {
+  Json::Value root = AuthorityBase(kLeaseType);
+  root["leaseExpiresAt"] = Json::Int64(kNowMs + 60'000);
+  root["daemonGeneration"] = 7;
+  root["mode"] = kViewMode;
+  root["inputEpoch"] = 0;
+
+  const auto parsed = ParseServiceSignal(root, kNowMs);
+  ASSERT_TRUE(parsed.has_value());
+  EXPECT_EQ(parsed->authority.lease_expires_at_ms, kNowMs + 60'000);
+}
+
 TEST(JsonProtocolTest, RejectsUnknownModeReasonAndMalformedCapability) {
   Json::Value root = AuthorityBase(kModeStateType);
   root["mode"] = kControlMode;

--- a/native/windows-remote-desktop/worker_policy.cc
+++ b/native/windows-remote-desktop/worker_policy.cc
@@ -8,6 +8,11 @@
 
 namespace imcodes::rd {
 
+bool DisplayOutputIsPresentable(bool imcodes_virtual,
+                                bool has_active_monitor_target) {
+  return imcodes_virtual || has_active_monitor_target;
+}
+
 CaptureAcquireAction ClassifyCaptureAcquireResult(HRESULT result) {
   if (result == S_OK) return CaptureAcquireAction::kFrame;
   if (result == DXGI_ERROR_WAIT_TIMEOUT) return CaptureAcquireAction::kWait;

--- a/native/windows-remote-desktop/worker_policy.h
+++ b/native/windows-remote-desktop/worker_policy.h
@@ -220,6 +220,21 @@ struct DisplaySelectionCandidate {
   bool imcodes_virtual = false;
 };
 
+/**
+ * Whether a DXGI output represents a desktop that Windows is actually
+ * presenting to a monitor target.
+ *
+ * A disconnected GPU output can remain `AttachedToDesktop` and continue to
+ * yield Desktop Duplication frames even though EnumDisplayDevices reports no
+ * monitor beneath the source. DWM may then omit DirectComposition surfaces,
+ * producing a deceptively live but incomplete desktop. Treat that
+ * half-headless source as unavailable so initial preparation requests the
+ * in-box virtual display. The exact IM.codes virtual display is allowed while
+ * its monitor target is still settling after activation.
+ */
+bool DisplayOutputIsPresentable(bool imcodes_virtual,
+                                bool has_active_monitor_target);
+
 // Prefers the still-available selected real display. If the selected output is
 // the exact IM.codes headless display and a real output appears, prefer a real
 // primary/available output. Returns candidates.size() when none is usable.

--- a/native/windows-remote-desktop/worker_policy_unittest.cc
+++ b/native/windows-remote-desktop/worker_policy_unittest.cc
@@ -287,6 +287,13 @@ TEST(WorkerPolicyTest, LeavesTheHeadlessDisplayWhenARealDisplayAppears) {
             0u);
 }
 
+TEST(WorkerPolicyTest, RejectsHalfHeadlessPhysicalOutput) {
+  EXPECT_FALSE(DisplayOutputIsPresentable(false, false));
+  EXPECT_TRUE(DisplayOutputIsPresentable(false, true));
+  EXPECT_TRUE(DisplayOutputIsPresentable(true, false));
+  EXPECT_TRUE(DisplayOutputIsPresentable(true, true));
+}
+
 TEST(WorkerPolicyTest, RequiresExplicitChoiceWhenSelectedDisplayDisappears) {
   const std::vector<DisplaySelectionCandidate> displays = {
       {"new-primary", true, true, false},

--- a/server/test/remote-desktop-router.test.ts
+++ b/server/test/remote-desktop-router.test.ts
@@ -779,6 +779,62 @@ describe('RemoteDesktopRouter', () => {
     }
   });
 
+  it('keeps the bounded controller lease alive through a brief revalidation stall', async () => {
+    vi.useFakeTimers();
+    try {
+      vi.setSystemTime(1_800_000_000_000);
+      let resolveRenewal!: (value: ControlledMachineAccessRow | null) => void;
+      let calls = 0;
+      const f = fixture({
+        resolveAccess: async () => {
+          calls++;
+          if (calls === 1) return validAccess(Date.now());
+          return new Promise<ControlledMachineAccessRow | null>((resolve) => {
+            resolveRenewal = resolve;
+          });
+        },
+      });
+      const authority = await authorize(f);
+      const authorized = f.messages(f.browserA)[0]!;
+      expect(authorized.leaseExpiresAt)
+        .toBe(Date.now() + REMOTE_DESKTOP_LIMITS.LEASE_DURATION_MS);
+      f.router.handleDaemon({
+        type: REMOTE_DESKTOP_MSG.STATUS,
+        ...authority,
+        mode: REMOTE_DESKTOP_ACCESS_MODE.CONTROL,
+        inputEpoch: 1,
+        state: REMOTE_DESKTOP_STATE.DIRECT,
+        route: 'direct',
+        inputEnabled: false,
+      }, 7);
+
+      // A slow permission lookup must not make a healthy controller lose its
+      // worker lease before the lookup has a chance to complete.  This crossed
+      // the old 15 s lease (and therefore caught the production failure) while
+      // remaining below the new one-minute fail-closed bound.
+      await vi.advanceTimersByTimeAsync(REMOTE_DESKTOP_LIMITS.LEASE_RENEW_INTERVAL_MS);
+      await vi.advanceTimersByTimeAsync(30_000);
+      expect(f.router.stats().active).toBe(1);
+      expect(f.messages(f.browserA)).not.toEqual(expect.arrayContaining([
+        expect.objectContaining({
+          type: REMOTE_DESKTOP_MSG.TERMINAL,
+          reason: REMOTE_DESKTOP_TERMINAL_REASON.LEASE_EXPIRED,
+        }),
+      ]));
+
+      resolveRenewal(validAccess(Date.now()));
+      await vi.advanceTimersByTimeAsync(0);
+      expect(f.daemonMessages.at(-1)).toMatchObject({
+        type: REMOTE_DESKTOP_MSG.LEASE,
+        ...authority,
+        leaseExpiresAt: Date.now() + REMOTE_DESKTOP_LIMITS.LEASE_DURATION_MS,
+      });
+      f.router.stopAll();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it('caps lifetime before TURN expiry and lets the worker fail closed on Server registry loss', async () => {
     vi.useFakeTimers();
     try {

--- a/shared/remote-desktop.ts
+++ b/shared/remote-desktop.ts
@@ -308,8 +308,15 @@ export const REMOTE_DESKTOP_LIMITS = {
   // showed healthy direct sessions taking about 10s, so the former 15s bound
   // cut off normal cold starts with almost no scheduling/network headroom.
   NEGOTIATION_TIMEOUT_MS: 45_000,
-  LEASE_DURATION_MS: 15_000,
-  LEASE_RENEW_INTERVAL_MS: 5_000,
+  // The lease remains a fail-closed backstop: if the Server can no longer
+  // revalidate the controller, the native worker stops itself without relying
+  // on a best-effort STOP frame.  Fifteen seconds, however, left only two
+  // renewal opportunities after a normal 5 s tick.  A brief database stall,
+  // daemon reconnect, or Windows scheduling pause could therefore end a live
+  // session as `lease_expired`.  Keep the bound short enough to contain an
+  // orphaned session, while leaving three full renewal windows for recovery.
+  LEASE_DURATION_MS: 60_000,
+  LEASE_RENEW_INTERVAL_MS: 15_000,
   KEEPALIVE_TIMEOUT_MS: 15_000,
   DATA_KEEPALIVE_INTERVAL_MS: 30_000,
   MEDIA_PROGRESS_TIMEOUT_MS: 10_000,

--- a/src/agent/providers/claude-code-sdk.ts
+++ b/src/agent/providers/claude-code-sdk.ts
@@ -84,7 +84,6 @@ const DEFAULT_CLAUDE_AUTH_REFRESH_WAIT_MS = 2 * 60 * 1000;
 const DEFAULT_CLAUDE_AUTH_REFRESH_POLL_MS = 500;
 const CLAUDE_AUTH_RECOVERY_GUIDANCE = 'Authentication recovery required: run `/logout`, fully exit Claude Code, then reopen it and run `/login` before retrying.';
 const CLAUDE_SDK_INPUT_PRIORITIES = {
-  IMMEDIATE: 'now',
   NEXT_SAFE_BOUNDARY: 'next',
 } as const;
 
@@ -792,12 +791,12 @@ export class ClaudeCodeSdkProvider implements TransportProvider, InteractiveQues
       message: { role: 'user', content: notification.text },
       parent_tool_use_id: null,
       uuid: notification.notificationId,
-      // Queue append is not a user interrupt. `now` preempts the current
-      // Agent SDK turn (which makes the UI look as if the agent slept); `next`
-      // drains after the current tool result and before the next model request.
-      priority: isQueuedUserMessage
-        ? CLAUDE_SDK_INPUT_PRIORITIES.NEXT_SAFE_BOUNDARY
-        : CLAUDE_SDK_INPUT_PRIORITIES.IMMEDIATE,
+      // `now` preempts the current Agent SDK turn. A delegation/audit reply is
+      // new information for the live task, not a request to stop that task, so
+      // it must take the same non-preemptive path as an explicit queue append.
+      // `next` is still injected into the active query after its current tool
+      // result — it does not wait for the normal idle FIFO to drain.
+      priority: CLAUDE_SDK_INPUT_PRIORITIES.NEXT_SAFE_BOUNDARY,
       origin: isQueuedUserMessage
         ? { kind: 'human' }
         : {

--- a/test/agent/claude-code-sdk-provider.test.ts
+++ b/test/agent/claude-code-sdk-provider.test.ts
@@ -137,7 +137,7 @@ describe('ClaudeCodeSdkProvider', () => {
     childProcessMock.spawn.mockClear();
   });
 
-  it('pushes a correlated peer notification into the live Claude query without closing it', async () => {
+  it('queues a correlated peer notification at Claude\'s next safe boundary without closing the live query', async () => {
     sdkMock.setWaitForClose(true);
     const provider = new ClaudeCodeSdkProvider();
     await provider.connect({ binaryPath: 'claude' });
@@ -161,7 +161,9 @@ describe('ClaudeCodeSdkProvider', () => {
     expect(queue.buffer?.at(-1)).toMatchObject({
       type: 'user',
       uuid: 'notification_identity',
-      priority: 'now',
+      // `now` preempts the Agent SDK turn; a completed audit/delegation reply
+      // must arrive during the active query without stopping its work.
+      priority: 'next',
       shouldQuery: true,
       isSynthetic: true,
       origin: {

--- a/web/src/components/QuickInputPanel.tsx
+++ b/web/src/components/QuickInputPanel.tsx
@@ -728,7 +728,9 @@ export function QuickInputPanel({
           )}
         </div>
 
-        {/* Controlled-node tab — display names are mutable, ref names are stable. */}
+        {/* Controlled-node tab — display names are mutable, ref names are
+            stable. Connectivity is informational: an offline node can still
+            be referenced in a task and resolve once it reconnects. */}
         {activeTab === 'machines' && machines.length > 0 && (
           <div class="qp-machine-items" role="listbox" aria-label={t('quick_input.tab_machines')}>
             <div class="qp-alias-hint">{t('machine.usage_hint')}</div>
@@ -737,10 +739,9 @@ export function QuickInputPanel({
                 key={machine.serverId}
                 type="button"
                 class={`qp-machine-item${machine.online ? '' : ' is-offline'}`}
-                disabled={!machine.online || !onInsertMachine}
+                disabled={!onInsertMachine}
                 title={machine.online ? machine.displayName : t('machine.offline_hint')}
                 onClick={() => {
-                  if (!machine.online) return;
                   onInsertMachine?.(machine.refName, machine.displayName);
                   onClose();
                 }}

--- a/web/test/quick-input-machine-tab.test.tsx
+++ b/web/test/quick-input-machine-tab.test.tsx
@@ -1,8 +1,8 @@
 /**
  * @vitest-environment jsdom
  *
- * Controlled nodes appear in Quick Input only when available. Selecting an
- * online node inserts its stable ref marker; offline nodes are not selectable.
+ * Controlled nodes appear in Quick Input only when available. Selecting any
+ * node inserts its stable ref marker; offline is an informational state.
  */
 import { cleanup, fireEvent, render } from '@testing-library/preact';
 import { afterEach, describe, expect, it, vi } from 'vitest';
@@ -54,7 +54,7 @@ describe('QuickInputPanel controlled-node tab', () => {
     expect(document.body.textContent).not.toContain('quick_input.tab_machines');
   });
 
-  it('inserts the stable ref of an online node and disables offline nodes', () => {
+  it('inserts stable refs for online and offline nodes while preserving offline status', () => {
     const onInsertMachine = vi.fn();
     const onClose = vi.fn();
     render(<QuickInputPanel {...props({
@@ -73,9 +73,12 @@ describe('QuickInputPanel controlled-node tab', () => {
     expect(document.body.textContent).toContain('^^(office-pc)');
 
     const nodeButtons = Array.from(document.body.querySelectorAll<HTMLButtonElement>('.qp-machine-item'));
-    expect(nodeButtons[1].disabled).toBe(true);
+    expect(nodeButtons[1].disabled).toBe(false);
+    expect(nodeButtons[1].classList.contains('is-offline')).toBe(true);
+    fireEvent.click(nodeButtons[1]);
+    expect(onInsertMachine).toHaveBeenCalledWith('lab-pc', 'Lab PC');
     fireEvent.click(nodeButtons[0]);
     expect(onInsertMachine).toHaveBeenCalledWith('office-pc', 'Renamed Office PC');
-    expect(onClose).toHaveBeenCalledOnce();
+    expect(onClose).toHaveBeenCalledTimes(2);
   });
 });


### PR DESCRIPTION
Promotes the already-green dev changes to production.

Includes remote-desktop monitorless-output and transient-lease recovery fixes, plus their dependent web/audit fixes.

Live diagnosis on desktop-nimvsfl-06a904 shows a dev.4003 node worker waiting for browser signaling while production master lacks these updates; keep server/web/node protocol behavior in the same release generation.